### PR TITLE
Support OpenStack Wallaby and openEuler new repo URL

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -30,5 +30,5 @@ jobs:
           flake8 --count .
       - name: Run
         run: |
-          python VersionStatus.py -r victoria/21.03 -n docs/index.html
+          python VersionStatus.py -r victoria/21.03,wallaby/21.09 -n docs/index.html
           file docs/index.html

--- a/.github/workflows/page-publish.yaml
+++ b/.github/workflows/page-publish.yaml
@@ -27,7 +27,7 @@ jobs:
           pip install -r requirements.txt
       - name: Generate OS Version Checker Page
         run: |
-          python VersionStatus.py -r victoria/21.03,rocky/20.03-LTS-SP2 -n docs/index.html
+          python VersionStatus.py -r victoria/21.03,wallaby/21.09,rocky/20.03-LTS-SP2 -n docs/index.html
       - name: Publish
         uses: peaceiris/actions-gh-pages@v3
         with:

--- a/VersionStatus.py
+++ b/VersionStatus.py
@@ -11,7 +11,10 @@ import requests
 from packaging import version
 
 OS_URI = "https://releases.openstack.org/{}"
-RPM_OS_URI = "https://repo.openeuler.org/openEuler-{0}/{1}/{2}/Packages/"
+RPM_OS_URI_LEGACY = \
+    "https://repo.openeuler.org/openEuler-{0}/{1}/{2}/Packages/"
+LEGACY_VERSION = ['openEuler-20.03-LTS', 'openEuler-20.03-LTS-SP1', '21.03']
+RPM_OS_URI = "https://repo.openeuler.org/openEuler-{0}/{1}/main/{2}/Packages/"
 RPM_DIRECTORY = ["EPOL", "everything", "update"]
 STATUS_NONE = ["0", "NONE"]
 STATUS_OUTDATED = ["1", "OUTDATED"]
@@ -45,8 +48,11 @@ class ReleasesConfig:
                 self.releases_config[release]['rpm_os_ver_uri'] = list()
                 if check_openeuler:
                     for _dir in RPM_DIRECTORY:
+                        _url = RPM_OS_URI \
+                            if to_os_version not in LEGACY_VERSION \
+                            else RPM_OS_URI_LEGACY
                         self.releases_config[release]['rpm_os_ver_uri'].append(
-                            RPM_OS_URI.format(to_os_version, _dir, arch))
+                            _url.format(to_os_version, _dir, arch))
             if 'os_ver_uri' not in self.releases_config[release]:
                 self.releases_config[release]['os_ver_uri'] = list()
                 self.releases_config[release]['os_ver_uri'].append(


### PR DESCRIPTION
openEuler repository have been updated to support multiversion
software store, the default repository path have been changed,
add compatibility logic to handle legacy version, like: 21.03,
20.03-LTS, 20.03-LTS-SP1.

Related-with: #2