### PR TITLE
Update regex string to find oepkg rpm package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,4 +10,4 @@ RUN mkdir /opt/app/images_versions && \
     chmod 777 /opt/app/images_versions
 
 ENTRYPOINT [ "python3", "./VersionStatus.py"]
-CMD [  "-r", "victoria-21.03,queens-rocky,rocky-20.03-LTS-SP1" ]
+CMD [  "-r", "victoria/21.03,queens/rocky,rocky/20.03-LTS-SP1" ]

--- a/VersionStatus.py
+++ b/VersionStatus.py
@@ -145,7 +145,7 @@ class RPMVersions:
                 continue
             uri_content = r.content.decode()
             # get all links, which ends .rpm from HTML
-            links = re.findall(r'\shref="(.*\.rpm)"\s', uri_content)
+            links = re.findall(r'<a href="(.*\.rpm)"[ >]', uri_content)
             for _link in links:
                 pkg_link = _rpm_os_ver_uri + _link
                 # get name and package information from link


### PR DESCRIPTION
1. oepkg repository rpm path is different with openEuler EPOL,
   update regex to find both of them.
2. Update Dockerfile input string

Fix: #2