### PR TITLE
Support openEuler 20.03 LTS SP3 release

### DIFF
--- a/.github/workflows/ci-gate-jobs.yaml
+++ b/.github/workflows/ci-gate-jobs.yaml
@@ -15,8 +15,8 @@ jobs:
           wallaby/21.09,\
           queens/20.03-LTS-SP2,\
           rocky/20.03-LTS-SP2,\
+          train/20.03-LTS-SP3,\
           train/dev-20.03-LTS-Next,\
-          train/dev-20.03-LTS-SP3,\
           "
     outputs:
       check-input: ${{ env.check-input }}

--- a/.github/workflows/publish-page.yaml
+++ b/.github/workflows/publish-page.yaml
@@ -16,8 +16,8 @@ jobs:
         wallaby/21.09,\
         queens/20.03-LTS-SP2,\
         rocky/20.03-LTS-SP2,\
+        train/20.03-LTS-SP3,\
         train/dev-20.03-LTS-Next,\
-        train/dev-20.03-LTS-SP3,\
         "
     strategy:
       matrix:


### PR DESCRIPTION
1. Add openEuler 20.03 LTS SP3 release
2. Remove openEuler 20.03 LTS SP3 dev target

Related-With: #15