### PR TITLE
Make latest release at the first page

### DIFF
--- a/.github/workflows/ci-gate-jobs.yaml
+++ b/.github/workflows/ci-gate-jobs.yaml
@@ -11,12 +11,12 @@ jobs:
   check-on-x86-64:
     env:
       check-input: "\
-          victoria/21.03,\
-          wallaby/21.09,\
-          queens/20.03-LTS-SP2,\
-          rocky/20.03-LTS-SP2,\
+          train/dev-22.03-LTS-Next,\
           train/20.03-LTS-SP3,\
-          train/dev-20.03-LTS-Next,\
+          rocky/20.03-LTS-SP2,\
+          queens/20.03-LTS-SP2,\
+          wallaby/21.09,\
+          victoria/21.03,\
           "
     outputs:
       check-input: ${{ env.check-input }}

--- a/.github/workflows/publish-page.yaml
+++ b/.github/workflows/publish-page.yaml
@@ -12,12 +12,12 @@ jobs:
   publish:
     env:
       publish-input: "\
-        victoria/21.03,\
-        wallaby/21.09,\
-        queens/20.03-LTS-SP2,\
-        rocky/20.03-LTS-SP2,\
+        train/dev-22.03-LTS-Next,\
         train/20.03-LTS-SP3,\
-        train/dev-20.03-LTS-Next,\
+        rocky/20.03-LTS-SP2,\
+        queens/20.03-LTS-SP2,\
+        wallaby/21.09,\
+        victoria/21.03,\
         "
     strategy:
       matrix:


### PR DESCRIPTION
Change the os-version-checker page order, make the latest dev and
release at the top of page list, reduce clicking.

Related-With: #15