### PR TITLE
Support dev 119 environment 22.03 LTS and LTS Next

### DIFF
--- a/.github/workflows/ci-gate-jobs.yaml
+++ b/.github/workflows/ci-gate-jobs.yaml
@@ -17,6 +17,10 @@ jobs:
           queens/20.03-LTS-SP2,\
           wallaby/21.09,\
           victoria/21.03,\
+          train/dev-20.03-LTS-Next,\
+          train/dev-20.03-LTS-SP3,\
+          train/dev-20.03-LTS-SP1,\
+          train/dev-21.09,\
           "
     outputs:
       check-input: ${{ env.check-input }}
@@ -24,7 +28,7 @@ jobs:
       matrix:
         os: [ubuntu-20.04, ubuntu-latest]
         arch: ['x86_64']
-        python-version: ['3.8', '3.x']
+        python-version: ['3.8']
     runs-on: ${{ matrix.os }}
     name: Test it on ${{ matrix.os }} ${{ matrix.arch }} with python${{ matrix.python-version }}
     steps:

--- a/VersionStatus.py
+++ b/VersionStatus.py
@@ -13,13 +13,19 @@ from packaging import version
 OS_URI = "https://releases.openstack.org/{}"
 RPM_OS_LEGACY_URI = \
     "https://repo.openeuler.org/openEuler-{0}/EPOL/{1}/Packages/"
-RPM_LEGACY_VERSION = ['20.03-LTS', '20.03-LTS-SP1', '21.03']
+RPM_LEGACY_VERSION = ['20.03-LTS', '20.03-LTS-SP1',
+                      '20.09', '21.03']
 RPM_OS_URI = "https://repo.openeuler.org/openEuler-{0}/EPOL/main/{1}/Packages/"
 RPM_OEPKG_URI = 'https://repo.oepkgs.net/openEuler/rpm/'\
                 'openEuler-{0}/budding-openeuler/'\
                 'openstack/{1}/{2}/Packages/'
-RPM_119_URI = 'http://119.3.219.20:82/openEuler:/{0}:/{1}:/{2}:/'\
-              'Epol/standard_{3}/{4}/'
+RPM_119_LEGACY_URI = 'http://119.3.219.20:82/openEuler:/{0}/{1}/{2}/'\
+                     'Epol/standard_{3}/{4}/'
+RPM_119_LEGACY_VERSION = ['20.03-LTS', '20.03-LTS-SP1', '20.03-LTS-SP2',
+                          '20.03-LTS-SP3', '20.03-LTS-Next',
+                          '20.09', '21.03', '21.09']
+RPM_119_URI = 'http://119.3.219.20:82/openEuler:/{0}/{1}/{2}/'\
+              'Epol:/Multi-Version:/OpenStack:/{5}/standard_{3}/{4}'
 RPM_119_SUB_DIR = 'noarch'
 OPENSTACK_IN_OEPKG_VERSION = ['queens', 'rocky']
 STATUS_NONE = ["0", "NONE"]
@@ -65,17 +71,22 @@ class ReleasesConfig:
                         _url.format(to_os_version, arch))
             # openstack vs 119 openEuler
             elif to_os_version.startswith('dev-'):
-                _url = RPM_119_URI
                 to_os_version = to_os_version[4:]
-                _version_parts = to_os_version.split('-')
+                _url = RPM_119_LEGACY_URI \
+                    if to_os_version in RPM_119_LEGACY_VERSION else RPM_119_URI
+                _parts = to_os_version.split('-')
+                # pad placeholder in URI
+                _version_parts = [_parts[i] + ':' if i < len(_parts) else ''
+                                  for i in range(3)]
                 # LTS Next and release
                 if len(_version_parts) > 1:
                     # aarch64
-                    _version_parts.extend([arch, arch])
+                    _version_parts.extend([arch, arch,
+                                           from_os_version.capitalize()])
                     self.releases_config[release]['rpm_os_ver_uri'].append(
                         _url.format(*_version_parts))
                     # noarch
-                    _version_parts[-1] = RPM_119_SUB_DIR
+                    _version_parts[-2] = RPM_119_SUB_DIR
                     self.releases_config[release]['rpm_os_ver_uri'].append(
                         _url.format(*_version_parts))
                 # Mainline and innovation release


### PR DESCRIPTION
1. Add new multi version directory of 22.03 LTS dev environment
2. Keep forward compatibility for legacy dev URI
3. Add forward compatibility check in CI job

Related-With: #15