### PR TITLE
Support 22.03-LTS OpenStack multiple version

### DIFF
--- a/.github/workflows/ci-gate-jobs.yaml
+++ b/.github/workflows/ci-gate-jobs.yaml
@@ -11,6 +11,8 @@ jobs:
   check-on-x86-64:
     env:
       check-input: "\
+          train/22.03-LTS,\
+          wallaby/22.03-LTS,\
           train/dev-22.03-LTS-Next,\
           wallaby/dev-22.03-LTS-Next,\
           train/20.03-LTS-SP3,\

--- a/.github/workflows/publish-page.yaml
+++ b/.github/workflows/publish-page.yaml
@@ -12,8 +12,9 @@ jobs:
   publish:
     env:
       publish-input: "\
+        train/22.03-LTS,\
+        wallaby/22.03-LTS,\
         train/dev-22.03-LTS-Next,\
-        wallaby/dev-22.03-LTS-Next,\
         train/20.03-LTS-SP3,\
         rocky/20.03-LTS-SP2,\
         queens/20.03-LTS-SP2,\


### PR DESCRIPTION
1. Support OpenStack multiple version in openEuler 22.03-LTS
2. Remove dev-22.03-LTS-NEXT because it have been released.

Related-With: #15